### PR TITLE
Drhuffman12/upgrade to crystal 1.1.1 (and 1.2.0-dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,4 @@ https://docs.couchdb.org/en/2.3.1/api/database/find.html#sort-syntax
 ## Original Project Contributors (what I've forked)
 - [TechMagister](https://github.com/TechMagister) Arnaud Fernandés - creator, maintainer
 - [Schniz](https://github.com/Schniz) Gal Schlezinger - contributor
-
-
-
-
+- [drhuffman12](https://github.com/drhuffman12) Daniel Huffman - contributor

--- a/shard.yml
+++ b/shard.yml
@@ -8,3 +8,8 @@ authors:
 crystal: 1.0.0
 
 license: MIT
+
+dependencies:
+  json_mapping:
+    github: crystal-lang/json_mapping.cr
+    

--- a/shard.yml
+++ b/shard.yml
@@ -1,15 +1,15 @@
 name: couchdb
-version: 0.3.0
+version: 0.4.0
 
 authors:
   - Arnaud Fernandés <arnaud.fernandes@tech-magister.com>
   - fork maintained by vectorselector
 
-crystal: 1.0.0
+# NOTE: Instead of hard-coding version in this file, specify 'works with' elsewise (e.g.: Release notes?)
+# crystal: 1.0.0
 
 license: MIT
 
 dependencies:
   json_mapping:
     github: crystal-lang/json_mapping.cr
-    

--- a/spec/couchdb_spec.cr
+++ b/spec/couchdb_spec.cr
@@ -3,14 +3,38 @@ require "./spec_helper"
 require "../src/couchdb/client"
 
 describe CouchDB do
+  it "version in shard.yml matches version in CouchDB::VERSION" do
+    (`shards version .`).strip.should eq(CouchDB::VERSION)
+  end
 
   describe CouchDB::Client do
-    it "should get server info" do
-      client = new_client
-      info = client.server_info
-      info.couchdb.should eq "Welcome"
-      info.version.should match /^2\.\d+\.\d+$/
-      info.vendor.name.should eq "The Apache Software Foundation"
+    context "should get server info re" do
+      it "couchdb" do
+        client = new_client
+        info = client.server_info
+        info.couchdb.should eq "Welcome"
+      end
+
+      context "version" do
+        context "is supported version of" do
+          it "2.x.x or 3.x.x" do
+            client = new_client
+            info = client.server_info
+  
+            # DEBUG: Which CouchDb Version is it?
+            p! info.is_v2? if info.is_v2?
+            p! info.is_v3? if info.is_v3?
+  
+            (info.is_v2? || info.is_v3?).should be_true
+          end
+        end
+      end
+
+      it "vendor.name" do
+        client = new_client
+        info = client.server_info
+        info.vendor.name.should eq "The Apache Software Foundation"
+      end
     end
 
     it "should create a database named testdb" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,7 +3,12 @@ require "spec"
 require "../src/couchdb"
 
 def new_client : CouchDB::Client
-  couchdb_url = ENV["TEST_DB"]? || "http://admin:password@localhost:5984"
+  un = ENV.keys.includes?("TEST_DB_UN") ? ENV["TEST_DB_UN"] : "admin"
+  pw = ENV.keys.includes?("TEST_DB_PW") ? ENV["TEST_DB_PW"] : "password"
+  ip = ENV.keys.includes?("TEST_DB_IP") ? ENV["TEST_DB_IP"] : "localhost"
+  port = ENV.keys.includes?("TEST_DB_PORT") ? ENV["TEST_DB_PORT"] : "5984"
+  couchdb_url = ENV.keys.includes?("TEST_DB") ? ENV["TEST_DB"] : "http://#{un}:#{pw}@#{ip}:#{port}"
+
   CouchDB::Client.new couchdb_url
 end
 

--- a/src/couchdb.cr
+++ b/src/couchdb.cr
@@ -3,6 +3,7 @@ require "./couchdb/client"
 require "./couchdb/database"
 require "./couchdb/response"
 require "./couchdb/find_query"
+require "json_mapping"
 
 module CouchDB
 

--- a/src/couchdb/response/server_info.cr
+++ b/src/couchdb/response/server_info.cr
@@ -1,11 +1,29 @@
 require "json"
 
 module CouchDB::Response
-
+  
   class Vendor
     include JSON::Serializable
     property name : String
-    property version : String
+
+    # property version : String
+    # NOTE: Above commented out (for now).
+    # TODO: Why "CouchDB::Response::Vendor#version" not getting parsed in?
+    #   WORK-AROUND: Use 'ServerInfo#version' instead of 'Vendor#version'.
+    #   ERROR: "JSON::SerializableError"
+    #     Missing JSON attribute: version
+    #     parsing CouchDB::Response::Vendor at line 1, column 205
+    #     parsing CouchDB::Response::ServerInfo#vendor at line 1, column 196 (JSON::SerializableError)
+    #     from /.../crystal/1.0.0/share/crystal/src/json/serialization.cr:159:7 in 'initialize:__pull_for_json_serializable'
+    #     from src/couchdb/response/server_info.cr:12:5 in 'new_from_json_pull_parser'
+    #     from src/couchdb/response/server_info.cr:12:5 in 'new'
+    #     from /.../crystal/1.0.0/share/crystal/src/json/from_json.cr:13:3 in 'from_json'
+    #     from src/couchdb/client.cr:50:18 in 'server_info'
+    #     from spec/couchdb_spec.cr:19:7 in '->'
+    #     ...
+    #     from __libc_start_main
+    #     from _start
+    #     from ???
   end
 
   class ServerInfo
@@ -15,5 +33,4 @@ module CouchDB::Response
     property version : String
     property vendor : Vendor
   end
-
 end

--- a/src/couchdb/response/server_info.cr
+++ b/src/couchdb/response/server_info.cr
@@ -32,5 +32,13 @@ module CouchDB::Response
     property uuid : String
     property version : String
     property vendor : Vendor
+
+    def is_v2?
+      !(/^2\.\d+\.\d+$/.match(version).nil?)
+    end
+
+    def is_v3?
+      !(/^3\.\d+\.\d+$/.match(version).nil?)
+    end
   end
 end

--- a/src/couchdb/response/server_info.cr
+++ b/src/couchdb/response/server_info.cr
@@ -7,23 +7,9 @@ module CouchDB::Response
     property name : String
 
     # property version : String
-    # NOTE: Above commented out (for now).
-    # TODO: Why "CouchDB::Response::Vendor#version" not getting parsed in?
-    #   WORK-AROUND: Use 'ServerInfo#version' instead of 'Vendor#version'.
-    #   ERROR: "JSON::SerializableError"
-    #     Missing JSON attribute: version
-    #     parsing CouchDB::Response::Vendor at line 1, column 205
-    #     parsing CouchDB::Response::ServerInfo#vendor at line 1, column 196 (JSON::SerializableError)
-    #     from /.../crystal/1.0.0/share/crystal/src/json/serialization.cr:159:7 in 'initialize:__pull_for_json_serializable'
-    #     from src/couchdb/response/server_info.cr:12:5 in 'new_from_json_pull_parser'
-    #     from src/couchdb/response/server_info.cr:12:5 in 'new'
-    #     from /.../crystal/1.0.0/share/crystal/src/json/from_json.cr:13:3 in 'from_json'
-    #     from src/couchdb/client.cr:50:18 in 'server_info'
-    #     from spec/couchdb_spec.cr:19:7 in '->'
-    #     ...
-    #     from __libc_start_main
-    #     from _start
-    #     from ???
+    @[Deprecated("Use `ServerInfo#version` instead of `Vendor#version`.")]
+    def version
+    end
   end
 
   class ServerInfo

--- a/src/couchdb/version.cr
+++ b/src/couchdb/version.cr
@@ -1,3 +1,3 @@
 module CouchDB
-  VERSION = "0.3.0"
+  VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
 end


### PR DESCRIPTION
-[x] Add dependency of `crystal-lang/json_mapping.cr`/ (`JSON.mapping` was deprecated and moved to shard.)
  * https://github.com/crystal-lang/crystal/pull/9527
  * https://github.com/crystal-lang/json_mapping.cr


-[x] Add more environment variables for database connection settings with defaults.
  * For now, just for tests:
    ```
      un = ENV.keys.includes?("TEST_DB_UN") ? ENV["TEST_DB_UN"] : "admin"
      pw = ENV.keys.includes?("TEST_DB_PW") ? ENV["TEST_DB_PW"] : "password"
      ip = ENV.keys.includes?("TEST_DB_IP") ? ENV["TEST_DB_IP"] : "localhost"
      port = ENV.keys.includes?("TEST_DB_PORT") ? ENV["TEST_DB_PORT"] : "5984"
      couchdb_url = ENV.keys.includes?("TEST_DB") ? ENV["TEST_DB"] : "http://#{un}:#{pw}@#{ip}:#{port}"
    ```

-[x] DEPRECATION: Use `ServerInfo#version` instead of `Vendor#version`.
  As of v3.x (or earlier?), a call to the server's root (e.g.: `GET http://127.0.0.1:5984/`)
    no longer returns `version` inside `vendor`.
  In v3.x, response will instead look like:

  ```
  {
    "couchdb":"Welcome",
    "version":"3.1.1",
    "git_sha":"ce596c65d",
    "uuid":"SOME_UUID_GOES_HERE",
    "features":["access-ready","partitioned","pluggable-storage-engines","reshard","scheduler"],
    "vendor":{"name":"The Apache Software Foundation"}
  }
  ```

-[x] Allow `3.x.x` versions of CouchDB.
  * Add `is_v2?` and `is_v3?` methods to `CouchDB::Response::ServerInfo`.

-[x] Remove hard-coded `crystal` key/version from `shard.yml` (for now).
  * Tested (and passed)
    * locally w/ `Crystal 1.1.1 [6d9a1d583] (2021-07-26)`
    * via CircleCI w/ `Crystal 1.2.0-dev [cadc4b3c7] (2021-09-02)`

-[x] Bump version of this shard to `0.4.0`
  * Set `CouchDB::VERSION` based on shard version value in from `shard.yml` (to avoid out-of-sync issues).

---

Next steps... see also:
* https://github.com/vectorselector/couchdb.cr/pull/2
* https://github.com/TechMagister/couchdb.cr/issues/13
* https://github.com/TechMagister/couchdb.cr/issues/14
* https://github.com/TechMagister/couchdb.cr/issues/15
